### PR TITLE
ignore build bits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.lock-wscript


### PR DESCRIPTION
This adds a .gitignore file to ignore build bits. I'm using node-png as a git submodule in a project and without this change the result of a build is a "dirty" tree:

```
$ git status
# On branch master
# Changed but not updated:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#
#       modified:   deps/node-png
#
no changes added to commit (use "git add" and/or "git commit -a")

$ git describe --dirty --long   # note the "-dirty"
20110901-0-gdd0b829-dirty
```
