### PR TITLE
Mark node 0.5 and newer unsupported in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
        "src": "src"
    },
    "engines": {
-       "node": ">=0.3.0"
+       "node": ">=0.3.0 <0.5"
    },
    "scripts": {
        "install": "node-waf configure build"


### PR DESCRIPTION
With this change, npm gives you an error message if you try to install node-png with node 0.5 or 0.6.

Related to this issue: https://github.com/pkrumins/node-png/issues/12
