### PR TITLE
Fix buf_type for proper alignment

### DIFF
--- a/src/png_encoder.cpp
+++ b/src/png_encoder.cpp
@@ -30,6 +30,7 @@ PngEncoder::PngEncoder(unsigned char *ddata, int wwidth, int hheight, buffer_typ
     data = ddata;
     width = wwidth;
     height = hheight;
+    buf_type = bbuf_type;
     png = NULL;
     png_len = 0;
     mem_len = 0;


### PR DESCRIPTION
The `buf_type` isn't being initialized properly in the `PngEncoder` constructor, so it's treating everything as RGBA (4-byte alignment).
