### PR TITLE
Add fifth argument to specify bits per pixel for grayscale images

### DIFF
--- a/examples/png-example4.js
+++ b/examples/png-example4.js
@@ -1,0 +1,23 @@
+/* Demonstrate a 16-bit grayscale image */
+
+var fs  = require('fs');
+var sys = require('sys');
+var Png = require('../png').Png;
+var Buffer = require('buffer').Buffer;
+
+var WIDTH = 300, HEIGHT = 300;
+
+var img_buffer = new Buffer(WIDTH*HEIGHT*2);
+
+for (var i=0; i<HEIGHT; i++) {
+  var val = 65535 * (i/HEIGHT) // make a vertical gradient
+    for (var j=0; j<WIDTH; j++) {
+        img_buffer[i*WIDTH*2 + j*2 + 0] = val >> 8;
+        img_buffer[i*WIDTH*2 + j*2 + 1] = val & 0xFF;
+    }
+}
+
+var png = new Png(img_buffer, WIDTH, HEIGHT, 'gray', 16);
+
+fs.writeFileSync('./png-gray-gradient-16.png', png.encodeSync().toString('binary'), 'binary');
+

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ image (in memory) from RGB or RGBA buffers.
 
 The module exports three objects: `Png`, `FixedPngStack` and `DynamicPngStack`.
 
-The `Png` object is for creating PNG images from an RGB or RGBA buffer.
+The `Png` object is for creating PNG images from an RGB, RGBA, or Grayscale buffer.
 The `FixedPngStack` is for joining a number of PNGs together (stacking them
 together) on a transparent blackground.
 The `DynamicPngStack` is for joining a number of PNGs together in the most
@@ -17,16 +17,17 @@ of some PNG and the rightmost bottom corner of some PNG).
 Png
 ---
 
-The `Png` object takes 4 arguments in its constructor:
+The `Png` object takes 5 arguments in its constructor:
 
 ``` javascript
-var png = new Png(buffer, width, height, buffer_type);
+var png = new Png(buffer, width, height, buffer_type, bits_per_pixel);
 ```
 
 The first argument, `buffer`, is a node.js `Buffer` filled with RGB(A) values.
 The second argument is integer width of the image.
 The third argument is integer height of the image.
 The fourth argument is 'rgb', 'bgr', 'rgba', 'bgra', or 'gray'. Defaults to 'rgb'.
+The fifth argument is valid only when buffer_type='gray'. Valid arguments are 8 (default) and 16.
 
 The constructed `png` object has the `encode` method that's asynchronous in nature.
 You give it a callback and it will call your function with a node.js Buffer object

--- a/src/dynamic_png_stack.cpp
+++ b/src/dynamic_png_stack.cpp
@@ -107,7 +107,7 @@ DynamicPngStack::PngEncodeSync()
     buffer_type pbt = (buf_type == BUF_BGR || buf_type == BUF_BGRA) ? BUF_BGRA : BUF_RGBA;
 
     try {
-        PngEncoder encoder(data, width, height, pbt);
+        PngEncoder encoder(data, width, height, pbt, 8);
         encoder.encode();
         free(data);
         int png_len = encoder.get_png_len();
@@ -253,7 +253,7 @@ DynamicPngStack::UV_PngEncode(uv_work_t *req)
         BUF_BGRA : BUF_RGBA;
 
     try {
-        PngEncoder encoder(data, png->width, png->height, pbt);
+        PngEncoder encoder(data, png->width, png->height, pbt, 8);
         encoder.encode();
         free(data);
         enc_req->png_len = encoder.get_png_len();

--- a/src/fixed_png_stack.cpp
+++ b/src/fixed_png_stack.cpp
@@ -56,7 +56,7 @@ FixedPngStack::PngEncodeSync()
     buffer_type pbt = (buf_type == BUF_BGR || buf_type == BUF_BGRA) ? BUF_BGRA : BUF_RGBA;
 
     try {
-        PngEncoder encoder(data, width, height, pbt);
+        PngEncoder encoder(data, width, height, pbt, 8);
         encoder.encode();
         int png_len = encoder.get_png_len();
         Buffer *retbuf = Buffer::New(png_len);
@@ -179,7 +179,7 @@ FixedPngStack::UV_PngEncode(uv_work_t *req)
     FixedPngStack *png = (FixedPngStack *)enc_req->png_obj;
 
     try {
-        PngEncoder encoder(png->data, png->width, png->height, png->buf_type);
+        PngEncoder encoder(png->data, png->width, png->height, png->buf_type, 8);
         encoder.encode();
         enc_req->png_len =encoder.get_png_len();
         enc_req->png = (char *)malloc(sizeof(*enc_req->png)*enc_req->png_len);

--- a/src/png.h
+++ b/src/png.h
@@ -10,12 +10,13 @@ class Png : public node::ObjectWrap {
     int width;
     int height;
     buffer_type buf_type;
+    int bits;
 
     static void UV_PngEncode(uv_work_t *req);
     static void UV_PngEncodeAfter(uv_work_t *req);
 public:
     static void Initialize(v8::Handle<v8::Object> target);
-    Png(int wwidth, int hheight, buffer_type bbuf_type);
+    Png(int wwidth, int hheight, buffer_type bbuf_type, int bbits);
     v8::Handle<v8::Value> PngEncodeSync();
 
     static v8::Handle<v8::Value> New(const v8::Arguments &args);

--- a/src/png_encoder.cpp
+++ b/src/png_encoder.cpp
@@ -26,11 +26,13 @@ PngEncoder::png_chunk_producer(png_structp png_ptr, png_bytep data, png_size_t l
     p->png_len += length;
 }
 
-PngEncoder::PngEncoder(unsigned char *ddata, int wwidth, int hheight, buffer_type bbuf_type) {
+PngEncoder::PngEncoder(unsigned char *ddata, int wwidth, int hheight,
+                       buffer_type bbuf_type, int bbits) {
     data = ddata;
     width = wwidth;
     height = hheight;
     buf_type = bbuf_type;
+    bits = bbits;
     png = NULL;
     png_len = 0;
     mem_len = 0;
@@ -65,7 +67,7 @@ PngEncoder::encode()
     }
 
     png_set_IHDR(png_ptr, info_ptr, width, height,
-        8, color_type, PNG_INTERLACE_NONE,
+        bits, color_type, PNG_INTERLACE_NONE,
         PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
 
     png_bytep *row_pointers = NULL;
@@ -90,7 +92,7 @@ PngEncoder::encode()
             break;
         case BUF_GRAY:
             for (int i=0; i<height; i++)
-                row_pointers[i] = data+i*width;
+                row_pointers[i] = data+(bits/8)*i*width;
             break;
         default:
             for (int i=0; i<height; i++)

--- a/src/png_encoder.h
+++ b/src/png_encoder.h
@@ -6,14 +6,14 @@
 #include "common.h"
 
 class PngEncoder {
-    int width, height;
+    int width, height, bits;
     unsigned char *data;
     char *png;
     unsigned int png_len, mem_len;
     buffer_type buf_type;
 
 public:
-    PngEncoder(unsigned char *ddata, int width, int hheight, buffer_type bbuf_type);
+    PngEncoder(unsigned char *ddata, int width, int hheight, buffer_type bbuf_type, int bbits);
     ~PngEncoder();
 
     static void png_chunk_producer(png_structp png_ptr, png_bytep data, png_size_t length);


### PR DESCRIPTION
Hi @pkrumins. First of all, thank you for the well written node wrapper on libpng. 

I've extended the Png class to accept a fifth argument which allows one to specify a 16bit pixel depth for grayscale images. Also included is an example of it in action. Since `dynamic_` and `fixed_` `png_stack` did not support grayscale, I did not bother to update them beyond providing the correct 8 bit default argument to Png/PngEncoder classes. 

We could set a default bit depth in the constructor for these classes, but my preference is to explicitly state it. I have no objection if you would prefer this behavior -- just a matter of coding style.
