### PR TITLE
Fix issue #38 Requiring png only exposes the Png() class

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -14,3 +14,4 @@ init(v8::Handle<v8::Object> target)
     DynamicPngStack::Initialize(target);
 }
 
+NODE_MODULE(png, init)

--- a/src/png.cpp
+++ b/src/png.cpp
@@ -227,5 +227,3 @@ Png::PngEncodeAsync(const Arguments &args)
 
     return Undefined();
 }
-
-NODE_MODULE(png, Png::Initialize)


### PR DESCRIPTION
Moves `NODE_MODULE()` into `module.cpp` so all classes get initialized
